### PR TITLE
Implemented docx loader

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -16,3 +16,4 @@ fpdf
 youtube-transcript-api
 pytube
 pymupdf
+python-docx


### PR DESCRIPTION
Implemented a new class DocLoader to handle docx files. 

Also made a change inside the URLLoader class to extract file type. Changed it to

file_type = url.rsplit('.')[-1]

from 

file_type = path.rsplit(".")[-1]

as it was not capable of handling urls like this: "https://www.dovepress.com/get_supplementary_file.php?f=285742.docx"  with multiple '.' at the end of the link. 